### PR TITLE
Error with default root parameter in settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ var defaults = production
 function bundle(settings, fn) {
   if (arguments.length == 1) fn = settings, settings = {};
   settings = assign(defaults, settings);
-  var root = settings.root || cwd;
+  var root = settings.root = settings.root || cwd;
   var entries = {};
 
   return function _bundle(settings2, path) {


### PR DESCRIPTION
Value of cwd never used because variable root rewrite again in function _bundle from both settings variables.
